### PR TITLE
Revert "Work around RAIL bugs when using Parquet input files"

### DIFF
--- a/rail_scripts/rail-estimate
+++ b/rail_scripts/rail-estimate
@@ -92,7 +92,7 @@ def parse_cmdline():
 
 
 def load_slow_modules(estimator):
-    global DEF_MAGLIMS, DS, ParquetEstimator, ParquetTableHandle, RailStage
+    global DEF_MAGLIMS, DS, Estimator, TableHandle, RailStage
 
     from rail.core.common_params import lsst_def_maglims as DEF_MAGLIMS
     from rail.core.data import TableHandle
@@ -113,45 +113,6 @@ def load_slow_modules(estimator):
 
     DS = RailStage.data_store
 
-    # Work around RAIL bugs
-    from pyarrow.parquet import ParquetFile
-    from math import ceil
-
-    class ParquetTableHandle(TableHandle):
-        @classmethod
-        def _size(cls, path, **kwargs):
-            with ParquetFile(path) as f:
-                return f.metadata.num_rows
-
-    class ParquetEstimator(Estimator):
-        name = "ParquetEstimator"
-
-        def input_iterator(self, tag, **kwargs):
-            """Iterate the input assocated to a particular tag
-
-            Parameters
-            ----------
-            tag : str
-                The tag (from cls.inputs or cls.outputs) for this data
-
-            kwargs : dict[str, Any]
-                These will be passed to the Handle's iterator method
-            """
-            handle = self.get_handle(tag, allow_missing=True)
-
-            # If data is in memory and not in a file, it means is small enough to process it
-            # in a single chunk.
-            if self.config.hdf5_groupname:
-                test_data = self.get_data('input')[self.config.hdf5_groupname]
-            else:
-                test_data = self.get_data('input')
-            max_l = 0
-            for k, v in test_data.items():
-                max_l = max(max_l, len(v))
-            self._input_length = max_l
-            s = 0
-            iterator=[[s, self._input_length, test_data]]
-            return iterator
 
 def setup_estimator(
     output,
@@ -166,10 +127,10 @@ def setup_estimator(
         column_template, column_template_error, DEF_MAGLIMS
     )
 
-    user_params = load_user_params(ParquetEstimator, estimator)
+    user_params = load_user_params(Estimator, estimator)
     user_params.update(column_info)
 
-    estimator = ParquetEstimator.make_stage(
+    estimator = Estimator.make_stage(
         name="estimate",
         model=estimator_config,
         output=output,
@@ -189,7 +150,7 @@ def load_input(file_name):
             "Input file name extension is required but missing: " '"%s"' % file_name
         )
 
-    input = DS.read_file("input", ParquetTableHandle, file_name)
+    input = DS.read_file("input", TableHandle, file_name)
     return input
 
 


### PR DESCRIPTION
The rail scripts will start using HDF5 input files and the newest versions of RAIL core seem to have fixed the problem with Parquet input files, so revert this patch. Reverting it will also allow processing input files by chunks.

This reverts commit 61df36690ccf2a687ca8b5a77a7734183b77a8e3.

This is a prerequisite pull request for all other pull requests.
