### PR TITLE
Generate HDF5 skinny tables by default

### DIFF
--- a/rail_scripts/rail-preprocess-parquet
+++ b/rail_scripts/rail-preprocess-parquet
@@ -47,6 +47,7 @@ from math import ceil
 from os.path import basename, join, splitext
 from sys import argv, stderr
 
+import tables_io
 from docopt import docopt
 from numpy import log, log10, multiply, nan_to_num, nan
 from pyarrow import ArrowInvalid
@@ -56,7 +57,7 @@ from rail_scripts import DEFAULT_BANDS, VERSION_TEXT, abort, error, info, \
         map_bands
 
 BUFFER_SIZE = 1<<20
-DEFAULT_EXT = '.pq'
+DEFAULT_EXT = '.hdf5'
 
 Configuration = namedtuple('Configuration',
                            ('input', 'output_dir', 'flux_template',
@@ -210,7 +211,7 @@ def preprocess(cfg):
                 output_name = build_output_name(cfg.input, i,
                                                 cfg.output_template)
                 output_path = join(cfg.output_dir, output_name)
-                table.to_parquet(output_path)
+                tables_io.write(table, output_path)
                 print(output_path)
 
     except ArrowInvalid as e:


### PR DESCRIPTION
After some issue reports to the upstream and the mention that the Parquet format wasn't going to be supported at first, it was decided to switch the default format for the skinny tables to HDF5.