### PR TITLE
46 implement support to rails tpz

### DIFF
--- a/rail_scripts/install-pz-rail
+++ b/rail_scripts/install-pz-rail
@@ -22,14 +22,17 @@ conda install -y pandas
 conda install -y matplotlib
 conda install -y psutil
 conda install -y cython
+conda install -y mpi4py
 
 pip install joblib
 pip install scikit-learn
 pip install scikit-learn-intelex
 CFLAGS="-L $CONDA_PREFIX/lib -I $CONDA_PREFIX/include" pip install fitsio
+CFLAGS="-O2 -DNDEBUG -std=gnu99" pip install pytdigest
 pip install flexcode
 
 # Install RAIL after all dependencies are installed
 pip install pz-rail
 pip install pz-rail-bpz
 pip install pz-rail-flexzboost
+pip install pz-rail-tpz

--- a/rail_scripts/rail-estimate
+++ b/rail_scripts/rail-estimate
@@ -21,7 +21,7 @@ Options:
                                               columns [default: magerr_{band}]
 
 
-Available algorithms: bpz, fzboost"""
+Available algorithms: bpz, fzboost, tpz"""
 
 from collections import namedtuple
 from os.path import splitext
@@ -108,6 +108,8 @@ def load_slow_modules(estimator):
             from rail.estimation.algos.flexzboost import FZBoost as Estimator
         except ImportError:
             from rail.estimation.algos.flexzboost import FlexZBoostEstimator as Estimator
+    elif estimator == 'tpz':
+        from rail.estimation.algos.tpz_lite import TPZliteEstimator as Estimator
     else:
         raise ValueError("Invalid estimator identifier: %s" % estimator)
 

--- a/rail_scripts/rail-estimate
+++ b/rail_scripts/rail-estimate
@@ -24,6 +24,7 @@ Options:
 Available algorithms: bpz, fzboost, tpz"""
 
 from collections import namedtuple
+from math import nan
 from os.path import splitext
 
 from docopt import docopt
@@ -125,12 +126,16 @@ def setup_estimator(
     hdf5_group="",
     num_bins=301,
 ):
-    column_info = create_column_mapping_dict(
-        column_template, column_template_error, DEF_MAGLIMS
-    )
+    extra_params = {}
 
-    user_params = load_user_params(Estimator, estimator)
-    user_params.update(column_info)
+    if estimator == 'tpz':
+        extra_params['nondetect_val'] = nan
+
+    extra_params.update(create_column_mapping_dict(
+        column_template, column_template_error, DEF_MAGLIMS
+    ))
+
+    extra_params.update(load_user_params(Estimator, estimator))
 
     estimator = Estimator.make_stage(
         name="estimate",
@@ -138,7 +143,7 @@ def setup_estimator(
         output=output,
         hdf5_groupname=hdf5_group,
         nzbins=num_bins,
-        **user_params
+        **extra_params
     )
 
     return estimator

--- a/rail_scripts/rail-train
+++ b/rail_scripts/rail-train
@@ -21,7 +21,7 @@ Options:
                                               columns [default: magerr_{band}]
 
 
-Available algorithms: bpz, fzboost
+Available algorithms: bpz, fzboost, tpz
 
 The generated output file contains the resulting trained state and is in Python
 pickle format. The default output name is "estimator_<algorithm>.pkl".'''
@@ -90,6 +90,10 @@ def load_slow_modules(estimator):
             from rail.estimation.algos.flexzboost import Inform_FZBoost as Trainer
         except ImportError:
             from rail.estimation.algos.flexzboost import FlexZBoostInformer as Trainer
+
+    elif estimator == 'tpz':
+        from rail.estimation.algos.tpz_lite import TPZliteInformer as Trainer
+
     else:
         raise ValueError('Invalid estimator identifier: %s' % estimator)
 

--- a/rail_scripts/rail-train
+++ b/rail_scripts/rail-train
@@ -27,6 +27,7 @@ The generated output file contains the resulting trained state and is in Python
 pickle format. The default output name is "estimator_<algorithm>.pkl".'''
 
 from collections import namedtuple
+from math import nan
 from os.path import splitext
 
 from docopt import docopt
@@ -35,7 +36,6 @@ from rail_scripts import ESTIMATOR_CONFIGURATION_TEMPLATE, VERSION_TEXT, \
         abort, error, create_column_mapping_dict, info
 
 from datetime import datetime 
-
 
 
 DEFAULT_ESTIMATOR = 'fzboost'
@@ -99,14 +99,20 @@ def load_slow_modules(estimator):
 
     DS = RailStage.data_store
 
-def setup_trainer(output, column_template, column_template_error, hdf5_group='',
-                  num_bins=301):
-    column_info = create_column_mapping_dict(
-            column_template, column_template_error, DEF_MAGLIMS)
+def setup_trainer(estimator, output, column_template, column_template_error,
+                  hdf5_group='', num_bins=301):
+    extra_info = {}
+
+    if estimator == 'tpz':
+        extra_info['nondetect_val'] = nan
+
+    extra_info.update(create_column_mapping_dict(
+            column_template, column_template_error, DEF_MAGLIMS))
+
 
     trainer = Trainer.make_stage(
             name='train', model=output, hdf5_groupname=hdf5_group,
-            nzbins=num_bins, **column_info)
+            nzbins=num_bins, **extra_info)
 
     return trainer
 
@@ -133,7 +139,7 @@ def setup(cfg):
 
     try:
         info('Configuring trainer...')
-        trainer = setup_trainer(cfg.output, cfg.column_template,
+        trainer = setup_trainer(cfg.estimator, cfg.output, cfg.column_template,
                                 cfg.column_template_error, cfg.hdf5_group,
                                 cfg.num_bins)
     except OSError as e:

--- a/rail_scripts/rail_scripts/__init__.py
+++ b/rail_scripts/rail_scripts/__init__.py
@@ -51,6 +51,8 @@ def create_column_mapping_dict(column_template, column_template_error, def_magli
 
     band_names = map_bands(column_template, bands)
     band_err_names = map_bands(column_template_error, bands)
+    band_to_error_dict = dict(zip(band_names, band_err_names))
+    band_to_error_dict['redshift'] = None
     ref_band = column_template.format(band="i")
 
     mag_limits = {
@@ -61,11 +63,14 @@ def create_column_mapping_dict(column_template, column_template_error, def_magli
     return {
         "bands": band_names,
         "band_names": band_names,
+        "use_atts": band_names,
         "err_bands": band_err_names,
         "band_err_names": band_err_names,
         "ref_band": ref_band,
         "prior_band": ref_band,
         "mag_limits": mag_limits,
+        "err_dict": band_to_error_dict,
+        "test_err_dict": band_to_error_dict,
     }
 
 


### PR DESCRIPTION
This patch set adds support for TPZ, while handling certain problems when dealing with NaN values. The training code is not yet stable and might give recursion errors, but debugging and discussions with the upstream are still ongoing. The patch set includes the branches "revert-workarounds" and "hdf5-skinny-tables-rebased".
