### PR TITLE
Reduce memory requirement in rail-slurm to 2140 MB

### DIFF
--- a/scheduler_examples/slurm/rail-slurm/rail-slurm.batch
+++ b/scheduler_examples/slurm/rail-slurm/rail-slurm.batch
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #SBATCH --time=16:00:00
 #SBATCH -J rail-slurm
-#SBATCH --mem-per-cpu=2200M
+#SBATCH --mem-per-cpu=2140M
 #SBATCH -p cpu
 #SBATCH --propagate=NPROC
 


### PR DESCRIPTION
This is required to fit in the new Apollo slurm configuration.