### PR TITLE
Implement HDF5 utilities

### DIFF
--- a/utils/hdf5-count-rows
+++ b/utils/hdf5-count-rows
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+from sys import argv
+from collections import namedtuple
+
+from pyarrow.parquet import ParquetFile
+from h5py import File, Group
+
+class State:
+    def __init__(self, rows=0):
+        self.rows = rows
+
+def on_visit(name, obj, state):
+    if isinstance(obj, Group):
+        return
+
+    state.rows = max(state.rows, len(obj))
+
+def main():
+    sum = 0
+
+    for i in argv[1:]:
+        with File(i) as f:
+            state = State()
+            f.visititems(lambda *a: on_visit(*a, state))
+            print(i, state.rows)
+            sum += state.rows
+
+    print(sum)
+
+if __name__ == '__main__': main()

--- a/utils/hdf5-linea
+++ b/utils/hdf5-linea
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Transform HDF5 file to a standard structure, used by LineA.
+#
+# - All datasets in the root ("/") group.
+# - Magnitude template name: mag_{band}.
+# - Magnitude error template name: magerr_{band}.
+
+from os.path import basename
+from sys import argv
+
+import h5py
+
+def transform_name(name):
+    return basename(name).removesuffix('_lsst').replace('mag_err', 'magerr')
+
+def on_visit(name, obj, out):
+    if isinstance(obj, h5py.Group):
+        return
+
+    out.create_dataset(transform_name(name), obj.shape, obj.dtype, obj)
+
+def main():
+    with h5py.File(argv[1], 'r') as r, h5py.File(argv[2], 'w') as w:
+        r.visititems(lambda *a: on_visit(*a, w))
+
+if __name__ == '__main__': main()


### PR DESCRIPTION
Two HDF5 utilities were implemented, to make it easy working with skinny tables in the HDF5 format:

- hdf5-count-rows: summarize the number of rows in a set of files
- hdf5-linea: convert the internal structure of HDF5 to LineA's format