### PR TITLE
Misc changes

### DIFF
--- a/rail_scripts/rail-estimate
+++ b/rail_scripts/rail-estimate
@@ -13,6 +13,8 @@ Options:
                                    [default: fzboost].
     -b <bins>, --bins=<bins>       Set number of bins (columns) in the resulting
                                    tables [default: 301].
+    -c <file>, --calibration-file=<file>  Set the name of the calibration file
+                                          [default: estimator_{algorithm}.pkl]
     -g <group>, --group=<group>    For HDF5 input, sets the group name (section)
                                    where input data is stored [default: ]
     -p <file>, --param-file=<file> Extra parameter file for the estimation
@@ -38,7 +40,7 @@ from rail_scripts import (
     abort,
     create_column_mapping_dict,
     error,
-    find_estimator_configuration,
+    find_data_file,
     info,
     load_user_params,
 )
@@ -66,7 +68,8 @@ def parse_cmdline():
     args = docopt(__doc__, version=VERSION_TEXT)
 
     estimator = args["--algorithm"]
-    config = find_estimator_configuration(args["--algorithm"])
+    calibration_file = args["--calibration-file"].format(algorithm=estimator)
+    calibration_file = find_data_file(calibration_file)
     hdf5_group = args["--group"]
     column_template = args["--column-template"]
     column_template_error = args["--column-template-error"]
@@ -88,7 +91,7 @@ def parse_cmdline():
             abort()
 
     info("Estimator algorithm: %s" % estimator)
-    info("Estimator calibration file: %s" % config)
+    info("Estimator calibration file: %s" % calibration_file)
     info("Bins: %d" % num_bins)
     info('HDF5 group name: "%s"' % hdf5_group)
     info('Column template for magnitude data: "%s"' % column_template)
@@ -99,7 +102,7 @@ def parse_cmdline():
         input=args["<input>"],
         output=args["<output>"],
         estimator=estimator,
-        estimator_config=config,
+        estimator_config=calibration_file,
         num_bins=num_bins,
         hdf5_group=hdf5_group,
         column_template=column_template,

--- a/rail_scripts/rail-estimate
+++ b/rail_scripts/rail-estimate
@@ -88,7 +88,7 @@ def parse_cmdline():
             abort()
 
     info("Estimator algorithm: %s" % estimator)
-    info("Configuration file: %s" % config)
+    info("Estimator calibration file: %s" % config)
     info("Bins: %d" % num_bins)
     info('HDF5 group name: "%s"' % hdf5_group)
     info('Column template for magnitude data: "%s"' % column_template)
@@ -203,7 +203,7 @@ def setup(cfg):
             cfg.num_bins,
         )
     except OSError as err:
-        error("Error: unable to load estimator configuration file.")
+        error("Error: unable to load estimator calibration file.")
         error(err)
         abort()
 

--- a/rail_scripts/rail_scripts/__init__.py
+++ b/rail_scripts/rail_scripts/__init__.py
@@ -36,12 +36,6 @@ def find_data_file(file_name):
     return file_name
 
 
-def find_estimator_configuration(model_name):
-    model_file = ESTIMATOR_CONFIGURATION_TEMPLATE % model_name
-
-    return find_data_file(model_file)
-
-
 def map_bands(template, bands):
     return [template.format(band=band) for band in bands]
 

--- a/scheduler_scripts/slurm/pz-compute.batch
+++ b/scheduler_scripts/slurm/pz-compute.batch
@@ -10,25 +10,25 @@
 # Usage:
 #
 #     $ sbatch [<sbatch_options>...] rail-slurm.batch \
-#             [<input_dir> [<output_dir> [<algorithm>]]]
+#             [<input_dir> [<output_dir> [<args>...]]]
 #
 # - input_dir: Input directory with pre-processed input data
 # - output_dir: Target output directory for the estimations
-# - algorithm: The estimation algorithm (fzboost or BPZ)
+# - args: Extra parameters passed to rail-estimate
 #
-# The rail-estimate program also requires an estimator_<algorithm>.pkl
-# file available in the current directory or in a standard data directory.
-# In case of BPZ algorithm, the BPZ cache files (AB directory) must have
-# been previously generated.
+# The rail-estimate program also requires by default an
+# estimator_<algorithm>.pkl file available in the current directory or in a
+# standard data directory.  In case of BPZ algorithm, the BPZ cache files (AB
+# directory) must have been previously generated.
 #
 # Example usage:
 #
-#     # Defaults: input_dir=input, output_dir=output, algorithm=fzboost
+#     # Defaults: input_dir=input, output_dir=output
 #     $ sbatch rail_slurm.batch
 #
-#     # Change the slurm queue
+#     # Change the slurm queue, change estimation algorithm to BPZ
 #     $ sbatch -p cpu_long -t 8:00:00 -N20 --ntasks-per-node=40 \
-#             input1 output1 bpz
+#             input1 output1 -a bpz
 #
 # This script is somewhat "Unix intensive" because it tries to exploit support
 # for dynamic scheduling on slurm. It calls "srun" in parallel and keeps calling
@@ -55,7 +55,6 @@ PROG = 'pz-compute'
 ESTIMATE = 'rail-estimate'
 OUTPUT_DIR = 'output'
 INPUT_DIR = 'input'
-ALGORITHM = 'fzboost'
 HELPER = 'pz-compute.run'
 MAX_ATTEMPTS = 3
 
@@ -95,8 +94,7 @@ def now(msg):
     yield
     info('%s: Finished: %s' % (datetime.now(), msg))
 
-def parallel(files, slots, input_dir, output_base_dir, algorithm, masks,
-             param_file):
+def parallel(files, slots, input_dir, output_base_dir, extra_args, masks):
     children = {}
     task_id = 0
     attempt = { file: 0 for file in files }
@@ -112,10 +110,7 @@ def parallel(files, slots, input_dir, output_base_dir, algorithm, masks,
             output_dir = dirname(output_file)
             stdout_file = stdout_name(task_id)
             stderr_file = stderr_name(task_id)
-            args = [ESTIMATE, '-a', algorithm, input_file, output_file]
-
-            if param_file:
-                args += ['-p', param_file]
+            args = [ESTIMATE, input_file, output_file] + extra_args
 
             makedirs(dirname(stdout_file), exist_ok=True)
             makedirs(dirname(stderr_file), exist_ok=True)
@@ -179,17 +174,8 @@ def parse_cmdline():
     else:
         output_dir = OUTPUT_DIR
 
-    if len(argv) > 3:
-        algorithm = argv[3]
-    else:
-        algorithm = ALGORITHM
-
-    if len(argv) > 4:
-        param_file = argv[4]
-    else:
-        param_file = None
-
-    return input_dir, output_dir, algorithm, param_file
+    extra_args = argv[3:]
+    return input_dir, output_dir, extra_args
 
 def find_program_paths():
     with now('finding program paths'):
@@ -255,12 +241,11 @@ def configure_threads(slots, node_list, task_list):
 
 def main():
     with now(PROG):
-        input_dir, output_dir, algorithm, param_file = parse_cmdline()
+        input_dir, output_dir, extra_args = parse_cmdline()
         slots, node_list, task_list = parse_slurm_variables()
         files = get_input_files(input_dir)
         find_program_paths()
         masks = configure_threads(slots, node_list, task_list)
-        parallel(files, slots, input_dir, output_dir, algorithm, masks,
-                 param_file)
+        parallel(files, slots, input_dir, output_dir, extra_args, masks)
 
 if __name__ == '__main__': main()

--- a/scheduler_scripts/slurm/pz-compute.batch
+++ b/scheduler_scripts/slurm/pz-compute.batch
@@ -53,7 +53,6 @@ SRUN_ARGS = [SRUN, '-n1', '-N1']
 LOG = 'log'
 PROG = 'pz-compute'
 ESTIMATE = 'rail-estimate'
-ESTIMATE_ARGS = ['--bins=301']
 OUTPUT_DIR = 'output'
 INPUT_DIR = 'input'
 ALGORITHM = 'fzboost'
@@ -113,8 +112,7 @@ def parallel(files, slots, input_dir, output_base_dir, algorithm, masks,
             output_dir = dirname(output_file)
             stdout_file = stdout_name(task_id)
             stderr_file = stderr_name(task_id)
-            args = [ESTIMATE] + ESTIMATE_ARGS + ['-a', algorithm] + \
-                    [input_file, output_file]
+            args = [ESTIMATE, '-a', algorithm, input_file, output_file]
 
             if param_file:
                 args += ['-p', param_file]

--- a/scheduler_scripts/slurm/pz-compute.batch
+++ b/scheduler_scripts/slurm/pz-compute.batch
@@ -150,7 +150,7 @@ def parallel(files, slots, input_dir, output_base_dir, algorithm, masks,
                     raise RuntimeError('Error: too many failed attempts.')
                 else:
                     info('Will retry again later.')
-                    files.appendleft(relative_path)
+                    files.appendleft(prev_relative_path)
                     sleep(0.2)
             else:
                 info('%s: Finished: %s %s id=%d' % (datetime.now(), ESTIMATE,

--- a/scheduler_scripts/slurm/pz-compute.py
+++ b/scheduler_scripts/slurm/pz-compute.py
@@ -9,6 +9,7 @@ from sys import argv, executable
 from yaml import safe_load
 
 SBATCH_ARGS = '-N 26 -n 2032'
+SBATCH_ARGS_TPZ = '-N 26 -n 1316 --mem-per-cpu=3500M'
 
 @dataclass
 class Configuration:
@@ -43,6 +44,9 @@ def load_configuration(conffile):
 
     if tmp:
         config = replace(config, **tmp)
+
+        if tmp.get('algorithm') == 'tpz' and not 'sbatch_args' in tmp:
+            config.sbatch_args = split(SBATCH_ARGS_TPZ)
 
     config.inputdir = to_path(config.inputdir)
     config.outputdir = to_path(config.outputdir)

--- a/scheduler_scripts/slurm/pz-compute.py
+++ b/scheduler_scripts/slurm/pz-compute.py
@@ -76,10 +76,10 @@ def setup(config):
 
 def run(config):
     cmd = [config.sbatch] + config.sbatch_args + [config.rail_slurm_batch,
-            config.inputdir, config.outputdir, config.algorithm]
+            config.inputdir, config.outputdir, '-a', config.algorithm]
 
     if config.param_file:
-        cmd.append(config.param_file)
+        cmd += ['-p', config.param_file]
 
     print(' '.join(str(x) for x in cmd))
     execv(config.sbatch, cmd)

--- a/scheduler_scripts/slurm/pz-compute.py
+++ b/scheduler_scripts/slurm/pz-compute.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from dataclasses import dataclass, field, replace
 from os import execv
+from os.path import expandvars
 from pathlib import Path
 from shlex import split
 from shutil import which
@@ -32,7 +33,7 @@ def parse_cmdline():
     return conffile
 
 def to_path(text):
-    return Path(text).expanduser()
+    return Path(expandvars(text)).expanduser()
 
 def load_configuration(conffile):
     config = Configuration()

--- a/scheduler_scripts/slurm/pz-compute.py
+++ b/scheduler_scripts/slurm/pz-compute.py
@@ -21,6 +21,7 @@ class Configuration:
     rail_slurm_batch: str = 'pz-compute.batch'
     rail_slurm_py: str = 'pz-compute.run'
     param_file: str = None
+    calib_file: str = None
 
 def parse_cmdline():
     try:
@@ -54,6 +55,9 @@ def load_configuration(conffile):
     if config.param_file:
         config.param_file = to_path(config.param_file)
 
+    if config.calib_file:
+        config.calib_file = to_path(config.calib_file)
+
     print(config)
 
     return config
@@ -80,6 +84,9 @@ def run(config):
 
     if config.param_file:
         cmd += ['-p', config.param_file]
+
+    if config.calib_file:
+        cmd += ['-c', config.calib_file]
 
     print(' '.join(str(x) for x in cmd))
     execv(config.sbatch, cmd)

--- a/scheduler_scripts/slurm/pz-train.batch
+++ b/scheduler_scripts/slurm/pz-train.batch
@@ -1,7 +1,6 @@
 #!/bin/sh
 #SBATCH --time=16:00:00
 #SBATCH -J pz-train
-#SBATCH --mem-per-cpu=2140M
 #SBATCH -p cpu
 #SBATCH --propagate=NPROC
 srun rail-train $@

--- a/scheduler_scripts/slurm/pz-train.py
+++ b/scheduler_scripts/slurm/pz-train.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from dataclasses import dataclass, field, replace
 from os import execv
+from os.path import expandvars
 from pathlib import Path
 from shlex import split
 from shutil import which
@@ -31,7 +32,7 @@ def parse_cmdline():
     return conffile
 
 def to_path(text):
-    return Path(text).expanduser()
+    return Path(expandvars(text)).expanduser()
 
 def load_configuration(conffile):
     config = Configuration()

--- a/scheduler_scripts/slurm/pz-train.py
+++ b/scheduler_scripts/slurm/pz-train.py
@@ -70,6 +70,9 @@ def setup(config):
     config.sbatch = find_prog(config.sbatch)
     find_prog(config.prog_batch)
 
+    if not config.inputfile.is_file():
+        raise RuntimeError('input file not found: %s' % config.inputfile)
+
 def run(config):
     cmd = [config.sbatch] + config.sbatch_args + [config.prog_batch,
             config.inputfile, config.outputfile, '-a', config.algorithm]

--- a/scheduler_scripts/slurm/pz-train.py
+++ b/scheduler_scripts/slurm/pz-train.py
@@ -9,7 +9,7 @@ from sys import argv, executable
 
 from yaml import safe_load
 
-SBATCH_ARGS = '-N 1 --ntasks-per-node=1'
+SBATCH_ARGS = '-N 1 --exclusive --ntasks-per-node=1 --mem=0'
 PROG = 'pz-train'
 OUTPUT_TEMPLATE = 'estimator_%s.pkl'
 


### PR DESCRIPTION
A patch set with many small modifications to the pz-compute project. It depends on the `slurm-frontend` branch. The list of changes follows:

- Use different default slurm parameters for TPZ (deal with excessive memory usage)
- Fix file name when retrying failed `rail-estimate` executions (wrong file being retried)
- Remove old hardcoded redundant parameter (`--bins=301`) when calling `rail-estimate`
- Give an error if the input file for `pz-train` doesn't exist
- Change nomenclature for pickle file from configuration to calibration
- Add command-line parameter to change the calibration file name
- Support passing through arbitrary parameters to `rail-estimate` in `pz-compute.batch`
- Support setting the calibration file name in the `pz-compute` configuration file
- Support using environment variables in paths in `pz-compute` and `pz-train` configuration files
