### PR TITLE
Add conda installation of numexpr to install-pz-rail

### DIFF
--- a/rail_scripts/install-pz-rail
+++ b/rail_scripts/install-pz-rail
@@ -23,6 +23,7 @@ conda install -y matplotlib
 conda install -y psutil
 conda install -y cython
 conda install -y mpi4py
+conda install -y numexpr
 
 pip install joblib
 pip install scikit-learn


### PR DESCRIPTION
This patch explicitly adds numexpr as part of the conda installation to avoid cases where the pip version is installed instead (in particular, when the default conda channel is set to conda-forge). The latest pip version of the package requires the glibc 2.27, which is not available in the current CentOS 7 installation and the source package is written in C++, but the compiler is also not available by default in the current installation.