### PR TITLE
Lazy load slow modules joblib and ceci

### DIFF
--- a/rail_scripts/rail-estimate
+++ b/rail_scripts/rail-estimate
@@ -32,7 +32,6 @@ from math import nan
 from os.path import splitext
 
 from docopt import docopt
-from joblib import parallel_config
 from yaml import YAMLError, safe_load
 
 from rail_scripts import (
@@ -112,11 +111,12 @@ def parse_cmdline():
 
 
 def load_slow_modules(estimator):
-    global DEF_MAGLIMS, DS, Estimator, TableHandle, RailStage
+    global DEF_MAGLIMS, DS, Estimator, TableHandle, RailStage, parallel_config
 
     from rail.core.common_params import lsst_def_maglims as DEF_MAGLIMS
     from rail.core.data import TableHandle
     from rail.core.stage import RailStage
+    from joblib import parallel_config
 
     if estimator == "bpz":
         try:

--- a/rail_scripts/rail_scripts/__init__.py
+++ b/rail_scripts/rail_scripts/__init__.py
@@ -1,7 +1,6 @@
 from os.path import isfile
 from sys import stderr
 import yaml
-import ceci
 
 from xdg.BaseDirectory import load_data_paths
 
@@ -96,6 +95,7 @@ def load_user_params(estimator, estimator_name):
 
 
 def set_estimator_param(name, value, default_params):
+    import ceci
     param = default_params.get(name)
     if isinstance(param, ceci.config.StageParameter) and isinstance(value, param.dtype):
         return value


### PR DESCRIPTION
This is a small performance optimization for when calling rail-estimate without parameters.

Before:

    $ time rail-estimate
    Usage:
        rail-estimate [options] [--] <input> <output>
        rail-estimate -h | --help
        rail-estimate --version

    real        0m8.423s
    user        0m0.370s
    sys         0m0.365s

After:

    $ time rail-estimate
    Usage:
        rail-estimate [options] [--] <input> <output>
        rail-estimate -h | --help
        rail-estimate --version

    real        0m0.105s
    user        0m0.047s
    sys         0m0.024s